### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
 endif
 
 TARGET_NAME := tgbdual
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 ifeq ($(ARCHFLAGS),)
 ifeq ($(archs),ppc)

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 ifeq ($(TARGET_ARCH),arm)
 LOCAL_CFLAGS += -DANDROID_ARM
 LOCAL_ARM_MODE := arm

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -35,7 +35,10 @@ struct retro_system_av_info *my_av_info = (retro_system_av_info*)malloc(sizeof(*
 void retro_get_system_info(struct retro_system_info *info)
 {
 	info->library_name = "TGB Dual";
-	info->library_version = "v0.8.3";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+	info->library_version = "v0.8.3" GIT_VERSION;
 	info->need_fullpath = false;
 	info->valid_extensions = "gb|gbc|sgb";
 }


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.