### PR TITLE
Compile with g++ on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ else
 	LD = link.exe
 endif
 else
-	LD = $(CC)
+	LD = $(CXX)
 endif
 
 INCFLAGS += $(INCFLAGS_PLATFORM)


### PR DESCRIPTION
Currently the core can't be loaded on Linux due to undefined symbols:

```
$ ldd -r tgbdual_libretro.so:
undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE (./tgbdual_libretro.so)
undefined symbol: _ZTVN10__cxxabiv120__si_class_type_infoE (./tgbdual_libretro.so)
undefined symbol: __gxx_personality_v0  (./tgbdual_libretro.so)
undefined symbol: _ZdlPv (./tgbdual_libretro.so)
undefined symbol: __cxa_guard_release (./tgbdual_libretro.so)
undefined symbol: _ZNSt8__detail15_List_node_base9_M_unhookEv (./tgbdual_libretro.so)
undefined symbol: _Znwm (./tgbdual_libretro.so)
undefined symbol: _ZNSt8__detail15_List_node_base7_M_hookEPS0_ (./tgbdual_libretro.so)
undefined symbol: _ZdlPvm (./tgbdual_libretro.so)
undefined symbol: __cxa_guard_acquire   (./tgbdual_libretro.so)
```

This was fixed already in 2ead87a00e1fc43c34cf92405f76c28168929fb0 but got reintroduced in 2758bc55260146c7d1f474e20f890ac0437a9a6e. (@twinaphex I'm not 100% sure if you reverted that on purpose, but it looks like a c&p error to me.) 

Closes #11