### PR TITLE
(3DS) Update target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,8 +212,11 @@ else ifeq ($(platform), ctr)
 	CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
+	FLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard
+	FLAGS += -Wall -mword-relocations
+	FLAGS += -fomit-frame-pointer -ffast-math
+	FLAGS += -DARM11 -D_3DS
 	STATIC_LINKING = 1
-	FLAGS += -D_3DS
 
 # Nintendo Switch (libtransistor)
 else ifeq ($(platform), switch)


### PR DESCRIPTION
Add missing compilation flags for 3DS target.

Core builds and runs on a new3DS.

Loading content the regular way works fine.
Dual gameboy emulation also works fine.

Loading roms through the subsystem menu, results in undefined behavior and often causes a crash.