### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 TGB Dual is an open source (GPLv2) GB/GBC emulator with game link cable support.
 
 This is a port of it to libretro.  To emulate two units side by side, use
+the core options in your frontend.  In older frontends, you'll need to use
 your frontend's "Sufami Turbo" interface, placing the ROMs in "slots" A and B.
 The Sufami Turbo BIOS itself can be any file; it is ignored by the emulator.
 Use the Player 1 and Player 2 controllers to control each unit.


### PR DESCRIPTION
It seems that README.md is rather outdated, in that RetroArch hasn't had the --sufamiA and --sufamiB arguments in years (and the situation seems similar for other libretro frontends).  The current description might seem a little bit intimidating, when it's actually quite easy to emulate two units with the core options.