### PR TITLE
Remove outdated Wii U compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,8 @@ else ifeq ($(platform), wiiu)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DHW_RVL -DWIIU -mwup -mcpu=750 -meabi -mhard-float -D__ppc__ -DMSB_FIRST -I$(DEVKITPRO)/libogc/include
+	CFLAGS += -DGEKKO -DHW_RVL -DWIIU -D__wiiu__ -DHW_WUP -ffunction-sections -fdata-sections
+	CFLAGS += -mcpu=750 -meabi -mhard-float -D__ppc__ -DMSB_FIRST -I$(DEVKITPRO)/libogc/include
 	CFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
 	STATIC_LINKING = 1
 


### PR DESCRIPTION
Proactive buildfix for after Wii U toolchain gets updated; safe to merge now.

See TimOelrichs/doublecherryGB-libretro#2 for further details.