### PR TITLE
Writing to VBK shall not be discarded if a dma transfert is ongoing

### DIFF
--- a/gb_core/cpu.cpp
+++ b/gb_core/cpu.cpp
@@ -503,8 +503,6 @@ void cpu::io_write(word adr,byte dat)
 			speed_change=dat&1;
 			return;
 		case 0xFF4F://VBK(内部VRAMバンク切り替え) // VBK (VRAM internal bank switching)
-			if (dma_executing)
-				return;
 			vram_bank=vram+0x2000*(dat&0x01);
 			ref_gb->get_cregs()->VBK=dat;//&0x01;
 			return;


### PR DESCRIPTION
Original code was discarding VBK register write if a DMA transfert is ongoing.
This page says :
https://problemkaputt.de/pandocs.htm#lcdvramdmatransferscgbonly
"Note that the program may not change the Destination VRAM bank (FF4F), or the Source ROM/RAM bank (in case data is transferred from bankable memory) until the transfer has completed!"
So even if game should check if DMA transfert is done before writing to VBK, it's still possible and it's done by some games (at least Shantae). No other GBC emulator is preventing writing to VRAM bank register in any case, so it's an error for sure in tgbdual.
Fixing the code allows Shantae to work as expected :
- Before the fix :
<img width="641" alt="shantae_bad" src="https://github.com/user-attachments/assets/86e2ccbd-3ac4-4d0e-8030-c62bf314b2eb" />

- After the fix :
<img width="642" alt="shantae_ok" src="https://github.com/user-attachments/assets/f84e2eb1-f029-4c9f-a558-a2bed8b33c99" />
