### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -145,6 +149,12 @@ libretro-build-windows-msvc05-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
Adds a `libretro-build-linux-aarch64` job so the core gets a Linux aarch64 nightly (currently missing from the buildbot).

The core already builds for aarch64 via the existing `android-arm64-v8a` job; the new job just mirrors `libretro-build-linux-x64` with the aarch64 make template. No architecture-specific flags in the generic `platform=unix` path.

**Tested on real aarch64 hardware** (Qualcomm Adreno 618, postmarketOS):
- Builds cleanly — `tgbdual_libretro.so` -> ELF 64-bit LSB shared object, ARM aarch64.
- Loads and runs in RetroArch: Super Mario Land boots into gameplay (160x144, GL/freedreno). No arch-specific issues.