### PR TITLE
Persist saves for two-player link content

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -40,8 +40,10 @@ static const struct retro_subsystem_memory_info gb2_memory[] = {
 };
 
 static const struct retro_subsystem_rom_info gb_roms[] = {
-    { "GameBoy #1", "gb|gbc", false, false, false, gb1_memory, 1 },
-    { "GameBoy #2", "gb|gbc", false, false, false, gb2_memory, 1 },
+    /* num_memory must cover both entries of the arrays above, or the
+       frontend never asks for the RTC and it is lost on exit */
+    { "GameBoy #1", "gb|gbc", false, false, false, gb1_memory, 2 },
+    { "GameBoy #2", "gb|gbc", false, false, false, gb2_memory, 2 },
 };
 
    static const struct retro_subsystem_info subsystems[] = {
@@ -395,6 +397,17 @@ bool retro_load_game_special(unsigned type, const struct retro_game_info *info, 
 
    check_variables();
 
+   /* Loading the two-player subsystem is itself the request for a link
+      cable: the frontend has already asked for two ROMs, and the save
+      files it will look for afterwards (GAMEBOY_1_SRAM/GAMEBOY_2_SRAM)
+      only exist while both Game Boys do.  With the core option left at its
+      default ("disabled") the second Game Boy was never created, mode
+      stayed MODE_SINGLE_GAME, both subsystem SRAM ids reported size 0 and
+      the frontend silently persisted nothing - the game then reports its
+      save as erased on the next launch. */
+   if (num_info >= 2 && info[1].data)
+      gblink_enable = true;
+
    environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
 
    render[0] = new dmy_renderer(0);
@@ -481,8 +494,11 @@ void *retro_get_memory_data(unsigned id)
             switch(id)
             {
                 case RETRO_MEMORY_SAVE_RAM:
+                case RETRO_MEMORY_GAMEBOY_1_SRAM: /* subsystem content with
+                                                     only one Game Boy */
                     return g_gb[0]->get_rom()->get_sram();
                 case RETRO_MEMORY_RTC:
+                case RETRO_MEMORY_GAMEBOY_1_RTC:
                     return &(render[0]->fixed_time);
                 case RETRO_MEMORY_VIDEO_RAM:
                     return g_gb[0]->get_cpu()->get_vram();
@@ -527,8 +543,10 @@ size_t retro_get_memory_size(unsigned id)
             switch(id)
             {
                 case RETRO_MEMORY_SAVE_RAM:
+                case RETRO_MEMORY_GAMEBOY_1_SRAM:
                     return g_gb[0]->get_rom()->get_sram_size();
                 case RETRO_MEMORY_RTC:
+                case RETRO_MEMORY_GAMEBOY_1_RTC:
                     return sizeof(render[0]->fixed_time);
                 case RETRO_MEMORY_VIDEO_RAM:
                     if (g_gb[0]->get_rom()->get_info()->gb_type >= 3)


### PR DESCRIPTION
Loading the "2 Player Game Boy Link" subsystem with `tgbdual_gblink_enable` at its default (`disabled`) throws both saves away — which is what a game reports as its data having been erased, and what #15 describes.

`retro_load_game_special()` only creates the second Game Boy when that option is on. Without it `mode` stays `MODE_SINGLE_GAME`, where the switches in `retro_get_memory_data()`/`retro_get_memory_size()` answer only `RETRO_MEMORY_SAVE_RAM`. But for subsystem content the frontend asks exclusively for the ids the subsystem declares — `GAMEBOY_1_SRAM` / `GAMEBOY_2_SRAM` — and those returned NULL/0, so nothing was ever written. In-game saving looks fine for the session; the save is simply gone at the next launch.

Loading that subsystem is itself the request for a link cable — the frontend has already asked the user for two ROMs — so when two ROMs arrive the link is enabled regardless of the option.

Two smaller things in the same area:

* `gb_roms[]` declared `num_memory = 1` while both `gb1_memory[]`/`gb2_memory[]` hold two entries, so the frontend never learned about the RTC and never saved it. It is `2` now, matching the arrays.
* `MODE_SINGLE_GAME` now answers the `GAMEBOY_1_*` ids alongside the plain ones, so subsystem content that ends up with a single Game Boy for any other reason still persists.

## Testing

RetroArch 1.22.2, `--subsystem gb_link_2p rom1.gb rom2.gb`, quit after ~20s:

| | before | after |
|---|---|---|
| files in the save dir | none | `rom1.srm` (8192), `rom1.rtc` (4), `rom2.srm` (8192), `rom2.rtc` (4) |
| log | no `[SRAM] Saved successfully` lines | four of them |

The `.rtc` files come from the `num_memory` fix, the `.srm` files from the link fix. Checked with a small harness as well: with the subsystem loaded and the option at its default, `retro_get_memory_size()` for `GAMEBOY_1_SRAM`/`GAMEBOY_2_SRAM` went from `0`/`0` to `8192`/`8192`, and a plain single-ROM load is unchanged.